### PR TITLE
Add support for closing the popup by single tap on the presented view

### DIFF
--- a/TESTZOOMOUT/ViewController.m
+++ b/TESTZOOMOUT/ViewController.m
@@ -45,6 +45,8 @@
     UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"myAn"]];
     
     zoomPopup *popup = [[zoomPopup alloc] initWithMainview:self.view andStartRect:_segmentedControl.frame];
+    [popup setShowCloseButton:NO]; //Disable close button
+    [popup setCloseOnTap:YES]; //Allow to close popup by single tap on the presented view
     [popup setBlurRadius:10];
     [popup showPopup:image];
     

--- a/ZoomOutControl/zoomPopup.h
+++ b/ZoomOutControl/zoomPopup.h
@@ -16,6 +16,7 @@
 @property (nonatomic) CGFloat shadowRadius;
 @property  (nonatomic) CGFloat backGroundAlpha;
 @property  (nonatomic) BOOL showCloseButton;
+@property  (nonatomic) BOOL closeOnTap;
 @property  (nonatomic) NSInteger blurRadius;
 
 
@@ -31,6 +32,7 @@
 +(void) setShadowRadius: ( CGFloat) shadowRadius;
 +(void) setBackgroundAlpha: (CGFloat) backGroundAlpha;
 +(void) showCloseButton: (BOOL) showCloseButton;
++(void) closeOnTap: (BOOL) closeOnTap;
 
 
 -(id) initWithMainview: (UIView*) mainView andStartRect: (CGRect) rect;

--- a/ZoomOutControl/zoomPopup.m
+++ b/ZoomOutControl/zoomPopup.m
@@ -22,6 +22,8 @@
     
 	UIView *mainView;
     
+    UITapGestureRecognizer *tgrClose;
+    
     
 	CGRect mainViewStartRect;
 	
@@ -77,7 +79,9 @@
 		_backGroundAlpha = 0.5;
 		_shadowRadius = 10.0;
         _showCloseButton = YES;
+        _closeOnTap = NO;
         _blurRadius = 0;
+        tgrClose = Nil;
 	}
     
 	return self;
@@ -139,7 +143,13 @@
         } else {
             _showCloseButton = NO; // No zoomPopupClose@2x.png or zoomPopupClose.png => no close button
         }
-	}
+    }
+    if (_closeOnTap){
+        //Support closing the popup by tap on the view
+        tgrClose = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(closePopup)];
+        [viewToDisplay addGestureRecognizer:tgrClose];
+        viewToDisplay.userInteractionEnabled = TRUE;
+    }
     
     
 	UIImage *imgSrc = [self imageWithView:mainView crop:mainViewStartRect];
@@ -198,6 +208,7 @@
 
 - (void)closePopup {
 	if (_showCloseButton) [closeButton removeFromSuperview];
+    if (tgrClose) [tgrClose.view removeGestureRecognizer:tgrClose];
 	[popupView removeFromSuperview];
 	[UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveEaseInOut animations: ^(void) {
 	    destImageView.alpha = 0.0;
@@ -232,6 +243,9 @@
 }
 +(void) showCloseButton: (BOOL) showCloseButton{
     [zoomPopup sharedInstance].showCloseButton = showCloseButton;
+}
++(void) closeOnTap: (BOOL) closeOnTap{
+    [zoomPopup sharedInstance].closeOnTap = closeOnTap;
 }
 
 


### PR DESCRIPTION
Adjusted example app so that the image popup does not have close indicator but can be closed by tap